### PR TITLE
VCST-4328: Update to .NET10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,11 +2,14 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.814.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-rvv3-g6hj-g44x" />
+  </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.News.Core/VirtoCommerce.News.Core.csproj
+++ b/src/VirtoCommerce.News.Core/VirtoCommerce.News.Core.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.890.0" />
-    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.801.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1002.0" />
+    <PackageReference Include="VirtoCommerce.Seo.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.News.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.News.Data.MySql/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.News.Data.Repositories.NewsDbContext -Project VirtoCommerce.News.Data.MySql -StartupProject VirtoCommerce.News.Data.MySql -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.News.Data.MySql/VirtoCommerce.News.Data.MySql.csproj
+++ b/src/VirtoCommerce.News.Data.MySql/VirtoCommerce.News.Data.MySql.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.890.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.MySql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.News.Data\VirtoCommerce.News.Data.csproj" />

--- a/src/VirtoCommerce.News.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.News.Data.PostgreSql/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.News.Data.Repositories.NewsDbContext -Project VirtoCommerce.News.Data.PostgreSql -StartupProject VirtoCommerce.News.Data.PostgreSql -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.News.Data.PostgreSql/VirtoCommerce.News.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.News.Data.PostgreSql/VirtoCommerce.News.Data.PostgreSql.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.890.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.PostgreSql" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.News.Data\VirtoCommerce.News.Data.csproj" />

--- a/src/VirtoCommerce.News.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.News.Data.SqlServer/Readme.md
@@ -1,22 +1,19 @@
-## Package manager
-```
-Add-Migration Initial -Context VirtoCommerce.News.Data.Repositories.NewsDbContext -Project VirtoCommerce.News.Data.SqlServer -StartupProject VirtoCommerce.News.Data.SqlServer -OutputDir Migrations -Verbose -Debug
+# Generate Migrations
+
+## Install CLI tools for Entity Framework Core
+```cmd
+dotnet tool install --global dotnet-ef --version 10.0.1
 ```
 
-### Entity Framework Core Commands
-```
-dotnet tool install --global dotnet-ef --version 8.*
+or update
+
+```cmd
+dotnet tool update --global dotnet-ef --version 10.0.1
 ```
 
-**Generate Migrations**
-```
-dotnet ef migrations add Initial -- "{connection string}"
-dotnet ef migrations add Update1 -- "{connection string}"
-dotnet ef migrations add Update2 -- "{connection string}"
-```
-etc..
+## Add Migration
+Select Data.<Provider> folder and run following command for each provider:
 
-**Apply Migrations**
-```
-dotnet ef database update -- "{connection string}"
+```cmd
+dotnet ef migrations add <migration-name>
 ```

--- a/src/VirtoCommerce.News.Data.SqlServer/VirtoCommerce.News.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.News.Data.SqlServer/VirtoCommerce.News.Data.SqlServer.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -9,12 +9,12 @@
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="[8.0.11,9)">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.890.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data.SqlServer" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.News.Data\VirtoCommerce.News.Data.csproj" />

--- a/src/VirtoCommerce.News.Data/VirtoCommerce.News.Data.csproj
+++ b/src/VirtoCommerce.News.Data/VirtoCommerce.News.Data.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.890.0" />
+    
+    <PackageReference Include="VirtoCommerce.Platform.Data" Version="3.1002.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.News.Core\VirtoCommerce.News.Core.csproj" />

--- a/src/VirtoCommerce.News.ExperienceApi/VirtoCommerce.News.ExperienceApi.csproj
+++ b/src/VirtoCommerce.News.ExperienceApi/VirtoCommerce.News.ExperienceApi.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.923.0" />
+    
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.News.Core\VirtoCommerce.News.Core.csproj" />

--- a/src/VirtoCommerce.News.Web/VirtoCommerce.News.Web.csproj
+++ b/src/VirtoCommerce.News.Web/VirtoCommerce.News.Web.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
+    <NoWarn>1591,NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->

--- a/src/VirtoCommerce.News.Web/module.manifest
+++ b/src/VirtoCommerce.News.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.News</id>
-  <version>3.814.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.890.0</platformVersion>
+  <platformVersion>3.1002.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.923.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
   </dependencies>
 
   <apps>
@@ -37,7 +37,7 @@
   <moduleType>VirtoCommerce.News.Web.Module, VirtoCommerce.News.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2025 VirtoCommerce. All rights reserved</copyright>
+  <copyright>Copyright © 2025-2026 VirtoCommerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/tests/VirtoCommerce.News.Tests/VirtoCommerce.News.Tests.csproj
+++ b/tests/VirtoCommerce.News.Tests/VirtoCommerce.News.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn>NU1608</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is a test project -->
@@ -12,9 +13,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.News.Core\VirtoCommerce.News.Core.csproj" />


### PR DESCRIPTION
## Description
Update to .NET10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4328
### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.News_3.1000.0-pr-17-7ba3.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades all projects to `net10.0` and bumps core platform/XAPI/EF dependencies, which can introduce runtime/build compatibility issues across the module and its DB providers. Changes are largely config/package-level but affect the entire build and test toolchain.
> 
> **Overview**
> **Upgrades the News module to .NET 10** by switching all projects (core, data providers, web, experience API, and tests) from `net8.0` to `net10.0`.
> 
> Aligns dependencies to the `3.100x` VirtoCommerce platform/XAPI stack and updates EF tooling (`Microsoft.EntityFrameworkCore.Design` `10.0.1`), including adding `NU1608` suppressions where needed.
> 
> Bumps module versioning (`VersionPrefix` and `module.manifest`) and adds a `NuGetAuditSuppress` entry for advisory `GHSA-rvv3-g6hj-g44x`; migration READMEs are refreshed to reference `dotnet-ef` `10.0.1`, and tests move to `xunit.v3` plus a newer `Microsoft.NET.Test.Sdk`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7ba30bcfc26bdaced9865e39bd699a21e5c6c209. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->