### PR TITLE
VCST-5223: Update to vc-shell 2.0.10

### DIFF
--- a/src/VirtoCommerce.News.Web/App/package.json
+++ b/src/VirtoCommerce.News.Web/App/package.json
@@ -19,8 +19,8 @@
     "@rollup/plugin-typescript": "^11.1.5",
     "@types/lodash-es": "^4.17.12",
     "@types/node": "^20.10.5",
-    "@vc-shell/api-client-generator": "^2.0.7",
-    "@vc-shell/ts-config": "^2.0.7",
+    "@vc-shell/api-client-generator": "^2.0.10",
+    "@vc-shell/ts-config": "^2.0.10",
     "@vitejs/plugin-vue": "^5.2.3",
     "@vue/eslint-config-prettier": "^10.2.0",
     "@vue/eslint-config-typescript": "^14.6.0",
@@ -44,8 +44,8 @@
     "vue-tsc": "^3.2.5"
   },
   "dependencies": {
-    "@vc-shell/config-generator": "^2.0.7",
-    "@vc-shell/framework": "^2.0.7",
+    "@vc-shell/config-generator": "^2.0.10",
+    "@vc-shell/framework": "^2.0.10",
     "@vueuse/core": "^10.7.1",
     "@vueuse/integrations": "^10.7.1",
     "cross-spawn": "^7.0.3",

--- a/src/VirtoCommerce.News.Web/App/src/modules/vc-news/pages/news-article-list-all.vue
+++ b/src/VirtoCommerce.News.Web/App/src/modules/vc-news/pages/news-article-list-all.vue
@@ -6,6 +6,10 @@
     width="40%"
   >
     <VcDataTable
+      v-model:active-item-id="selectedItemId"
+      v-model:sort-field="sortField"
+      v-model:sort-order="sortOrder"
+      v-model:selection="localSelection"
       :items="newsArticles"
       :total-count="pagination.totalCount"
       :pagination="pagination"
@@ -14,10 +18,6 @@
       :search-placeholder="$t('VC_NEWS.PAGES.LIST.SEARCH.PLACEHOLDER')"
       state-key="VC_NEWS"
       class="tw-grow tw-basis-0"
-      v-model:active-item-id="selectedItemId"
-      v-model:sort-field="sortField"
-      v-model:sort-order="sortOrder"
-      v-model:selection="localSelection"
       @row-click="onItemClick"
       @pagination-click="pagination.goToPage"
       @search="onSearchChange"

--- a/src/VirtoCommerce.News.Web/App/src/router/routes.ts
+++ b/src/VirtoCommerce.News.Web/App/src/router/routes.ts
@@ -4,7 +4,7 @@ import { Invite, Login, ResetPassword, ChangePasswordPage, ForgotPassword } from
 import whiteLogoImage from "/assets/logo-white.svg";
 import bgImage from "/assets/background.jpg";
 
-const version = import.meta.env.PACKAGE_VERSION;
+// const version = import.meta.env.PACKAGE_VERSION;
 
 export const routes: RouteRecordRaw[] = [
   {
@@ -27,7 +27,7 @@ export const routes: RouteRecordRaw[] = [
     path: "/login",
     component: Login,
     meta: {
-      appVersion: version,
+      // appVersion: version,
     },
     props: () => ({
       logo: whiteLogoImage,
@@ -50,7 +50,7 @@ export const routes: RouteRecordRaw[] = [
     path: "/forgot-password",
     component: ForgotPassword,
     meta: {
-      appVersion: version,
+      // appVersion: version,
     },
     props: () => ({
       logo: whiteLogoImage,

--- a/src/VirtoCommerce.News.Web/App/src/router/routes.ts
+++ b/src/VirtoCommerce.News.Web/App/src/router/routes.ts
@@ -4,8 +4,6 @@ import { Invite, Login, ResetPassword, ChangePasswordPage, ForgotPassword } from
 import whiteLogoImage from "/assets/logo-white.svg";
 import bgImage from "/assets/background.jpg";
 
-// const version = import.meta.env.PACKAGE_VERSION;
-
 export const routes: RouteRecordRaw[] = [
   {
     path: "/",
@@ -26,9 +24,6 @@ export const routes: RouteRecordRaw[] = [
     name: "Login",
     path: "/login",
     component: Login,
-    meta: {
-      // appVersion: version,
-    },
     props: () => ({
       logo: whiteLogoImage,
       title: "Vc News",
@@ -49,9 +44,6 @@ export const routes: RouteRecordRaw[] = [
     name: "ForgotPassword",
     path: "/forgot-password",
     component: ForgotPassword,
-    meta: {
-      // appVersion: version,
-    },
     props: () => ({
       logo: whiteLogoImage,
     }),

--- a/src/VirtoCommerce.News.Web/App/src/router/routes.ts
+++ b/src/VirtoCommerce.News.Web/App/src/router/routes.ts
@@ -2,7 +2,6 @@ import { RouteRecordRaw } from "vue-router";
 import App from "../pages/App.vue";
 import { Invite, Login, ResetPassword, ChangePasswordPage, ForgotPassword } from "@vc-shell/framework";
 import whiteLogoImage from "/assets/logo-white.svg";
-import bgImage from "/assets/background.jpg";
 
 export const routes: RouteRecordRaw[] = [
   {

--- a/src/VirtoCommerce.News.Web/App/yarn.lock
+++ b/src/VirtoCommerce.News.Web/App/yarn.lock
@@ -3050,9 +3050,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vc-shell/api-client-generator@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@vc-shell/api-client-generator@npm:2.0.7"
+"@vc-shell/api-client-generator@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/api-client-generator@npm:2.0.10"
   dependencies:
     chalk: "npm:^2.4.2"
     cross-spawn: "npm:^7.0.3"
@@ -3062,13 +3062,13 @@ __metadata:
     vite-plugin-dts: "npm:^3.6.4"
   bin:
     api-client-generator: dist/api-client-generator.js
-  checksum: 10/6d9a8c430c1213985223301ce158dea6494b2fec5f52c26b8bee4f560cfab37a99455fb50bf5c55df131f7dc23bbc3b2f20c1d2f3a35ce1dfce7351be6426961
+  checksum: 10/41648f51ba7094d74859ce4fdac816537349091a85ffcdee619fcfd31fbddd4494fc84a77977c5dfff3973abc7dbf2063d55056a5cb065b68e305be6a3c8cd31
   languageName: node
   linkType: hard
 
-"@vc-shell/config-generator@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@vc-shell/config-generator@npm:2.0.7"
+"@vc-shell/config-generator@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/config-generator@npm:2.0.10"
   dependencies:
     "@babel/parser": "npm:^7.27.0"
     "@vitejs/plugin-vue": "npm:^5.2.3"
@@ -3078,13 +3078,13 @@ __metadata:
     vite-plugin-circular-dependency: "npm:^0.5.0"
     vite-plugin-mkcert: "npm:^1.17.1"
     vue: "npm:^3.5.30"
-  checksum: 10/0583aaefcfba704f9bef2017420d4a06382c365e585a083c7efd12ceb6baa26704a946dfda3b78a8333069c4f625d8db701e0dd52f6273d20022d2b33b34801b
+  checksum: 10/6cfd3187b603faf747296efabab74c5377511731b1ec9137832ed2046d7800aeed392a53a292207ce23ced297b95d874024a3494fca9eef7bfca2a0f1080a059
   languageName: node
   linkType: hard
 
-"@vc-shell/framework@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@vc-shell/framework@npm:2.0.7"
+"@vc-shell/framework@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/framework@npm:2.0.10"
   dependencies:
     "@floating-ui/dom": "npm:^1.7.4"
     "@floating-ui/vue": "npm:^1.0.6"
@@ -3148,14 +3148,14 @@ __metadata:
       optional: false
   bin:
     vc-check-locales: dist/scripts/check-locales.cjs
-  checksum: 10/9a8f3740e08f2d7728f17b237f90c1240edb20e05073b4dada2a15360f99041177ebc36feb2d0ee0e8129e12e59c121384ae55599a0807255dba4205f5cf180b
+  checksum: 10/19dcf8cf9b0588ab7926a4b8a5d8123628bff76d4159f5122ea9178c7709b1623d4527e1615d8be994ee142cfe1b0d6cc210d5351a537b0313413a52ed3992e7
   languageName: node
   linkType: hard
 
-"@vc-shell/ts-config@npm:^2.0.7":
-  version: 2.0.7
-  resolution: "@vc-shell/ts-config@npm:2.0.7"
-  checksum: 10/c381f9f828cc70fdd64f47643795135b1cf834ac1cf25994d54f42fad002264c3555e47605a8533f2f16d2c18c641e3b3fdca33fba7cf4d61d16e0d2c9e4434b
+"@vc-shell/ts-config@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "@vc-shell/ts-config@npm:2.0.10"
+  checksum: 10/470a638c7adfa27b40425460c0922c55d76482a4bd1f2eabe22bd20900097f9667c344fd6f0d81ffcb916a15baf11d1ddf913ea8ae85961ac9634d47fde1c799
   languageName: node
   linkType: hard
 
@@ -9296,10 +9296,10 @@ __metadata:
     "@rollup/plugin-typescript": "npm:^11.1.5"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/node": "npm:^20.10.5"
-    "@vc-shell/api-client-generator": "npm:^2.0.7"
-    "@vc-shell/config-generator": "npm:^2.0.7"
-    "@vc-shell/framework": "npm:^2.0.7"
-    "@vc-shell/ts-config": "npm:^2.0.7"
+    "@vc-shell/api-client-generator": "npm:^2.0.10"
+    "@vc-shell/config-generator": "npm:^2.0.10"
+    "@vc-shell/framework": "npm:^2.0.10"
+    "@vc-shell/ts-config": "npm:^2.0.10"
     "@vitejs/plugin-vue": "npm:^5.2.3"
     "@vue/eslint-config-prettier": "npm:^10.2.0"
     "@vue/eslint-config-typescript": "npm:^14.6.0"


### PR DESCRIPTION
## Changes

- Bump `@vc-shell/*` packages from `2.0.7` to `2.0.10` (`api-client-generator`, `config-generator`, `framework`, `ts-config`)
- Reorder `VcDataTable` v-model bindings in `news-article-list-all.vue`
- Disable `appVersion` derived from package version in `routes.ts`

## Jira

[VCST-5223](https://virtocommerce.atlassian.net/browse/VCST-5223)

[VCST-5223]: https://virtocommerce.atlassian.net/browse/VCST-5223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.News_3.1004.0-pr-20-d973.zip